### PR TITLE
New cert

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -23,7 +23,7 @@ module SamlIdp
   end
 
   def self.new_metadata
-    @metadata ||= MetadataBuilder.new(config, true)
+    @new_metadata ||= MetadataBuilder.new(config, true)
   end
 end
 

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -21,6 +21,10 @@ module SamlIdp
   def self.metadata
     @metadata ||= MetadataBuilder.new(config)
   end
+
+  def self.new_metadata
+    @metadata ||= MetadataBuilder.new(config, true)
+  end
 end
 
 # TODO Needs extraction out

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -16,10 +16,11 @@ module SamlIdp
     attr_accessor :expiry
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
+    attr_accessor :new_cert
 
     delegate :config, to: :SamlIdp
 
-    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm, authn_context_classref, expiry=60*60, encryption_opts=nil, session_expiry=nil)
+    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm, authn_context_classref, expiry=60*60, encryption_opts=nil, session_expiry=nil, new_cert)
       self.reference_id = reference_id
       self.issuer_uri = issuer_uri
       self.principal = principal
@@ -31,6 +32,7 @@ module SamlIdp
       self.expiry = expiry
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry.nil? ? config.session_expiry : session_expiry
+      self.new_cert = new_cert
     end
 
     def fresh
@@ -40,7 +42,7 @@ module SamlIdp
         IssueInstant: now_iso,
         Version: "2.0" do |assertion|
           assertion.Issuer issuer_uri
-          sign assertion, audience_uri
+          sign assertion, new_cert
           assertion.Subject do |subject|
             subject.NameID name_id, Format: name_id_format[:name]
             subject.SubjectConfirmation Method: Saml::XML::Namespaces::Methods::BEARER do |confirmation|

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -63,6 +63,7 @@ module SamlIdp
       session_expiry = opts[:session_expiry]
       encryption_opts = opts[:encryption] || nil
       signed_message_opts = opts[:signed_message] || false
+      new_cert = opts[:new_cert] || false
 
       SamlResponse.new(
         reference_id,
@@ -77,7 +78,8 @@ module SamlIdp
         expiry,
         encryption_opts,
         session_expiry,
-        signed_message_opts
+        signed_message_opts,
+        new_cert
       ).build
     end
 
@@ -87,7 +89,8 @@ module SamlIdp
         (opts[:issuer_uri] || issuer_uri),
         saml_logout_url,
         saml_request_id,
-        (opts[:algorithm] || algorithm || default_algorithm)
+        (opts[:algorithm] || algorithm || default_algorithm),
+        opts[:new_cert] || false
       ).signed
     end
 

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -7,12 +7,14 @@ module SamlIdp
     attr_accessor :issuer_uri
     attr_accessor :saml_slo_url
     attr_accessor :algorithm
+    attr_accessor :new_cert
 
-    def initialize(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(response_id, issuer_uri, saml_slo_url, algorithm, new_cert)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_slo_url = saml_slo_url
       self.algorithm = algorithm
+      self.new_cert = new_cert
     end
 
     # this is an abstract base class.

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -3,8 +3,8 @@ module SamlIdp
   class LogoutRequestBuilder < LogoutBuilder
     attr_accessor :name_id
 
-    def initialize(response_id, issuer_uri, saml_slo_url, name_id, algorithm)
-      super(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(response_id, issuer_uri, saml_slo_url, name_id, algorithm, new_cert)
+      super(response_id, issuer_uri, saml_slo_url, algorithm, new_cert)
       self.name_id = name_id
     end
 
@@ -16,7 +16,7 @@ module SamlIdp
         Destination: saml_slo_url,
         "xmlns" => Saml::XML::Namespaces::PROTOCOL do |request|
           request.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
-          sign request, issuer_uri
+          sign request, new_cert
           request.NameID name_id, xmlns: Saml::XML::Namespaces::ASSERTION,
             Format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
           request.SessionIndex response_id_string

--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -3,8 +3,8 @@ module SamlIdp
   class LogoutResponseBuilder < LogoutBuilder
     attr_accessor :saml_request_id
 
-    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, algorithm)
-      super(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, algorithm, new_cert)
+      super(response_id, issuer_uri, saml_slo_url, algorithm, new_cert)
       self.saml_request_id = saml_request_id
     end
 
@@ -17,7 +17,7 @@ module SamlIdp
         InResponseTo: saml_request_id,
         xmlns: Saml::XML::Namespaces::PROTOCOL do |response|
           response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
-          sign response, issuer_uri
+          sign response, new_cert
           response.Status xmlns: Saml::XML::Namespaces::PROTOCOL do |status|
             status.StatusCode Value: Saml::XML::Namespaces::Statuses::SUCCESS
           end

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -22,7 +22,7 @@ module SamlIdp
           "xmlns:saml" => Saml::XML::Namespaces::ASSERTION,
           "xmlns:ds" => Saml::XML::Namespaces::SIGNATURE,
           entityID: entity_id do |entity|
-            sign entity, single_service_post_location
+            sign entity, new_cert
 
             entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration do |descriptor|
               build_key_descriptor descriptor
@@ -162,11 +162,6 @@ module SamlIdp
       .gsub(/-----END CERTIFICATE-----/,"")
       .gsub(/\n/, "")
     end
-
-    def service_provider_finder
-      SamlIdp.config.service_provider.finder
-    end
-    private :service_provider_finder
 
     %w[
       support_email

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -11,14 +11,16 @@ module SamlIdp
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
     attr_accessor :raw_algorithm
+    attr_accessor :new_cert
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
+    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm, new_cert)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
       self.raw_algorithm = raw_algorithm
+      self.new_cert = new_cert
     end
 
     def encoded(signed_message: false)
@@ -52,7 +54,7 @@ module SamlIdp
       builder = Builder::XmlMarkup.new
       builder.tag! "samlp:Response", resp_options do |response|
           response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
-          sign response, issuer_uri
+          sign response, new_cert
           response.tag! "samlp:Status" do |status|
             status.tag! "samlp:StatusCode", Value: Saml::XML::Namespaces::Statuses::SUCCESS
           end

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -18,6 +18,7 @@ module SamlIdp
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
     attr_accessor :signed_message_opts
+    attr_accessor :new_cert
 
     def initialize(reference_id,
           response_id,
@@ -31,7 +32,8 @@ module SamlIdp
           expiry=60*60,
           encryption_opts=nil,
           session_expiry=0,
-          signed_message_opts
+          signed_message_opts,
+          new_cert
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -48,6 +50,7 @@ module SamlIdp
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
       self.signed_message_opts = signed_message_opts
+      self.new_cert = new_cert
     end
 
     def build
@@ -73,7 +76,7 @@ module SamlIdp
     private :encoded_message
 
     def response_builder
-      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)
+      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm, new_cert)
     end
     private :response_builder
 
@@ -88,7 +91,8 @@ module SamlIdp
         authn_context_classref,
         expiry,
         encryption_opts,
-        session_expiry
+        session_expiry,
+        new_cert
     end
     private :assertion_builder
   end

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -20,7 +20,7 @@ module SamlIdp
       end
     end
 
-    def sign(el, new_cert = false)
+    def sign(el, new_cert)
       el << signature(new_cert) if sign?
     end
 

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -20,8 +20,8 @@ module SamlIdp
       end
     end
 
-    def sign(el, audience_uri)
-      el << signature(audience_uri) if sign?
+    def sign(el, new_cert = false)
+      el << signature(new_cert) if sign?
     end
 
     def generated_reference_id
@@ -64,14 +64,14 @@ module SamlIdp
     end
     private :sign?
 
-    def signature(audience_uri)
-      SignatureBuilder.new(signed_info_builder(audience_uri), audience_uri).raw
+    def signature(new_cert)
+      SignatureBuilder.new(signed_info_builder(new_cert), new_cert).raw
     end
     private :signature
 
-    def signed_info_builder(audience_uri)
+    def signed_info_builder(new_cert)
       SignedInfoBuilder.new(
-        get_reference_id, get_digest, get_algorithm, audience_uri
+        get_reference_id, get_digest, get_algorithm, new_cert
       )
     end
     private :signed_info_builder

--- a/lib/saml_idp/signature_builder.rb
+++ b/lib/saml_idp/signature_builder.rb
@@ -1,13 +1,12 @@
 require 'builder'
-require 'saml_idp/service_provider'
 
 module SamlIdp
   class SignatureBuilder
-    attr_accessor :signed_info_builder, :audience_service_provider
+    attr_accessor :signed_info_builder, :new_cert
 
-    def initialize(signed_info_builder, audience_service_provider)
+    def initialize(signed_info_builder, new_cert)
       self.signed_info_builder = signed_info_builder
-      self.audience_service_provider = audience_service_provider
+      self.new_cert = new_cert
     end
 
     def raw
@@ -23,20 +22,13 @@ module SamlIdp
       end
     end
 
-    def service_provider
-      @_service_provider ||=
-        ServiceProvider.new(
-          (service_provider_finder[audience_service_provider] || {})
-        )
-    end
-
     def x509_certificate
-      extract_x509_certificate(certificate_by_provider)
+      extract_x509_certificate(certificate_by_options)
     end
     private :x509_certificate
 
-    def certificate_by_provider
-      if service_provider.new_cert
+    def certificate_by_options
+      if new_cert
         SamlIdp.config.new_x509_certificate
       else
         SamlIdp.config.x509_certificate
@@ -63,9 +55,5 @@ module SamlIdp
     end
     private :signature_value
 
-    def service_provider_finder
-      SamlIdp.config.service_provider.finder
-    end
-    private :service_provider_finder
   end
 end

--- a/lib/saml_idp/signed_info_builder.rb
+++ b/lib/saml_idp/signed_info_builder.rb
@@ -22,13 +22,13 @@ module SamlIdp
     attr_accessor :reference_id
     attr_accessor :digest_value
     attr_accessor :raw_algorithm
-    attr_accessor :audience_uri
+    attr_accessor :new_cert
 
-    def initialize(reference_id, digest_value, raw_algorithm, audience_uri)
+    def initialize(reference_id, digest_value, raw_algorithm, new_cert)
       self.reference_id = reference_id
       self.digest_value = digest_value
       self.raw_algorithm = raw_algorithm
-      self.audience_uri = audience_uri
+      self.new_cert = new_cert
     end
 
     def raw
@@ -66,14 +66,8 @@ module SamlIdp
     end
     private :clean_algorithm_name
 
-    def service_provider
-      @_service_provider ||=
-        ServiceProvider.new((service_provider_finder[audience_uri] || {}))
-    end
-    private :service_provider
-
     def secret_key
-      if service_provider.new_cert
+      if new_cert
         SamlIdp.config.new_secret_key
       else
         SamlIdp.config.secret_key
@@ -96,10 +90,5 @@ module SamlIdp
       "#_#{reference_id}"
     end
     private :reference_string
-
-    def service_provider_finder
-      SamlIdp.config.service_provider.finder
-    end
-    private :service_provider_finder
   end
 end

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.8.6'
+  VERSION = '0.8.7'
 end

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -19,6 +19,7 @@ module SamlIdp
         key_transport: 'rsa-oaep-mgf1p',
       }
     end
+    let(:new_cert) { false }
     subject { described_class.new(
       reference_id,
       issuer_uri,
@@ -28,7 +29,8 @@ module SamlIdp
       saml_acs_url,
       algorithm,
       authn_context_classref,
-      expiry
+      expiry,
+      new_cert
     ) }
 
     context "No Request ID" do
@@ -78,7 +80,10 @@ module SamlIdp
           saml_acs_url,
           algorithm,
           authn_context_classref,
-          expiry
+          expiry,
+          nil,
+          nil,
+          new_cert
         )
         Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
           expect(builder.raw).to eq("<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2010-06-01T13:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">foo@example.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2010-06-01T13:03:00Z\" Recipient=\"http://saml.acs.url\"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore=\"2010-06-01T12:59:55Z\" NotOnOrAfter=\"2010-06-01T16:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AuthnStatement AuthnInstant=\"2010-06-01T13:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef></AuthnContext></AuthnStatement><AttributeStatement><Attribute Name=\"emailAddress\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" FriendlyName=\"emailAddress\"><AttributeValue>foo@example.com</AttributeValue></Attribute></AttributeStatement></Assertion>")
@@ -97,7 +102,9 @@ module SamlIdp
         algorithm,
         authn_context_classref,
         expiry,
-        encryption_opts
+        encryption_opts,
+        nil,
+        false
       )
       encrypted_xml = builder.encrypt
       expect(encrypted_xml).to_not match(audience_uri)
@@ -121,7 +128,9 @@ module SamlIdp
           algorithm,
           authn_context_classref,
           expiry,
-          encryption_opts
+          encryption_opts,
+          nil,
+          new_cert
         )
         expect(builder.session_expiry).to eq(8)
       end

--- a/spec/lib/saml_idp/logout_request_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_request_builder_spec.rb
@@ -16,6 +16,7 @@ module SamlIdp
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
     let(:name_id) { 'some_name_id' }
     let(:algorithm) { OpenSSL::Digest::SHA256 }
+    let(:new_cert) { false }
 
     subject do
       described_class.new(
@@ -23,7 +24,8 @@ module SamlIdp
         issuer_uri,
         saml_slo_url,
         name_id,
-        algorithm
+        algorithm,
+        new_cert
       )
     end
 

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -16,6 +16,7 @@ module SamlIdp
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
     let(:request_id) { 'some_request_id' }
     let(:algorithm) { OpenSSL::Digest::SHA256 }
+    let(:new_cert) { false }
 
     subject do
       described_class.new(
@@ -23,7 +24,8 @@ module SamlIdp
         issuer_uri,
         saml_slo_url,
         request_id,
-        algorithm
+        algorithm,
+        new_cert
       )
     end
 

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -50,20 +50,18 @@ module SamlIdp
     end
 
     context '#x509_certificate' do
-      context 'when the service provider has new certificate' do
+      context 'when the new cert flag is passed' do
         it 'extract new certificate' do
-          allow_any_instance_of(ServiceProvider).to(
-            receive(:new_cert).and_return true
-          )
+          subject.new_cert = true
           expect(subject.x509_certificate.length < 15).to(
             eq(Default::NEW_X509_CERTIFICATE.length < 15)
           )
         end
       end
 
-      context 'when the service provider does not have a new certificate' do
+      context 'when the new cert flag is not passed' do
         it 'extract default certificate' do
-          subject.configurator.single_service_post_location = nil
+          subject.new_cert = false
           expect(subject.x509_certificate.length < 15).to(
             eq(Default::X509_CERTIFICATE.length < 15)
           )

--- a/spec/lib/saml_idp/response_builder_spec.rb
+++ b/spec/lib/saml_idp/response_builder_spec.rb
@@ -6,12 +6,15 @@ module SamlIdp
     let(:saml_acs_url) { "http://sportngin.com" }
     let(:saml_request_id) { "134" }
     let(:assertion_and_signature) { "<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2013-07-31T05:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><signature>stuff</signature><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">jon.phenow@sportngin.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2013-07-31T05:03:00Z\" Recipient=\"http://saml.acs.url\"/></SubjectConfirmation></Subject><Conditions NotBefore=\"2013-07-31T04:59:55Z\" NotOnOrAfter=\"2013-07-31T06:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name=\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\"><AttributeValue>jon.phenow@sportngin.com</AttributeValue></Attribute></AttributeStatement><AuthnStatment AuthnInstant=\"2013-07-31T05:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatment></Assertion>" }
+    let(:new_cert) { false }
     subject { described_class.new(
       response_id,
       issuer_uri,
       saml_acs_url,
       saml_request_id,
-      assertion_and_signature
+      assertion_and_signature,
+      nil,
+      new_cert
     ) }
 
     before do

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -26,6 +26,7 @@ module SamlIdp
     end
     let(:signed_response_opts) { true }
     let(:unsigned_response_opts) { false }
+    let(:new_cert) { false }
     let(:subject_encrypted) { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -38,7 +39,8 @@ module SamlIdp
                                   expiry,
                                   encryption_opts,
                                   session_expiry,
-                                  unsigned_response_opts
+                                  unsigned_response_opts,
+                                  new_cert
                                  )
     }
 
@@ -54,7 +56,8 @@ module SamlIdp
                                   expiry,
                                   nil,
                                   session_expiry,
-                                  signed_response_opts
+                                  signed_response_opts,
+                                  new_cert
                                  )
     }
 

--- a/spec/lib/saml_idp/signable_spec.rb
+++ b/spec/lib/saml_idp/signable_spec.rb
@@ -5,9 +5,9 @@ class MockSignable
 
   def raw
     builder = Builder::XmlMarkup.new
-    audience_uri = ''
+    new_cert = false
     builder.body do |body|
-      sign body, audience_uri
+      sign body, new_cert
     end
   end
 

--- a/spec/lib/saml_idp/signature_builder_spec.rb
+++ b/spec/lib/saml_idp/signature_builder_spec.rb
@@ -4,10 +4,10 @@ module SamlIdp
     let(:signed) { "jvEbD/rsiPKmoXy7Lhm+FGn88NPGlap4EcPZ2fvjBnk03YESs87FXAIiZZEzN5xq4sBZksUmZe2bV3rrr9sxQNgQawmrrvr66ot7cJiv0ETFArr6kQIZaR5g/V0M4ydxvrfefp6cQVI0hXvmxi830pq0tISiO4J7tyBNX/kvhZk=" }
     let(:raw_info) { "<ds:SignedInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/><ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha256\"/><ds:Reference URI=\"#_abc\"><ds:Transforms><ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/><ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/></ds:Transforms><ds:DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha256\"/><ds:DigestValue>em8csGAWynywpe8S4nN64o56/4DosXi2XWMY6RJ6YfA=</ds:DigestValue></ds:Reference></ds:SignedInfo>" }
     let(:signed_info) { double raw: raw_info, signed: signed }
-    let(:audience_service_provider) { '' }
+    let(:new_cert) { false }
     subject { described_class.new(
       signed_info,
-      audience_service_provider
+      new_cert
     ) }
 
     before do
@@ -19,7 +19,7 @@ module SamlIdp
     end
 
     it 'return a new legit raw XML file' do
-      allow_any_instance_of(ServiceProvider).to receive(:new_cert).and_return true
+      subject.new_cert = true
       expect(subject.raw).to eq("<ds:Signature xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:SignedInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/><ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha256\"/><ds:Reference URI=\"#_abc\"><ds:Transforms><ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/><ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/></ds:Transforms><ds:DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha256\"/><ds:DigestValue>em8csGAWynywpe8S4nN64o56/4DosXi2XWMY6RJ6YfA=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>jvEbD/rsiPKmoXy7Lhm+FGn88NPGlap4EcPZ2fvjBnk03YESs87FXAIiZZEzN5xq4sBZksUmZe2bV3rrr9sxQNgQawmrrvr66ot7cJiv0ETFArr6kQIZaR5g/V0M4ydxvrfefp6cQVI0hXvmxi830pq0tISiO4J7tyBNX/kvhZk=</ds:SignatureValue><KeyInfo xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>MIIB6TCCAVICCQDAmGgQaQDUbDANBgkqhkiG9w0BAQUFADA5MQswCQYDVQQGEwJCUjEOMAwGA1UECAwFU3RhdGUxDjAMBgNVBAcMBVNldmVuMQowCAYDVQQKDAFDMB4XDTE5MDgxNTIyMzIyMloXDTMwMTAzMTIyMzIyMlowOTELMAkGA1UEBhMCQlIxDjAMBgNVBAgMBVN0YXRlMQ4wDAYDVQQHDAVTZXZlbjEKMAgGA1UECgwBQzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA2szkBhh8CKouSFJhud639J5s8XBwnTQigbEOs46QivPm5TZmAA97NlzRXzaZNHFenSSnSZ1ixqAeFjsQtvAyJXzHht2YQYtTGkGeDx/VarMOa9Qbe7H1vUPhNF1RPQ/fhfy0xldbXs2cP5ZrABeoJ07bKQI9GPumbC0l5ADOF9UCAwEAATANBgkqhkiG9w0BAQUFAAOBgQCxGL3wLLCsbDzAygV4ZTy/Xtakj2Es1v8ul0/375aYbt4FDkTDg3FTPzvijzNUPIwKh5CpdZpRQ3aKad5bQt1VdFrMTH3erUtwz7B1ml4zWCzJoAffTIjXK9VFHbX0jKl4L1Jrnw5PCtx4zceOBMOwgMONjcEuRL1p2MyT4ZrNtA==</ds:X509Certificate></ds:X509Data></KeyInfo></ds:Signature>")
     end
   end

--- a/spec/lib/saml_idp/signed_info_builder_spec.rb
+++ b/spec/lib/saml_idp/signed_info_builder_spec.rb
@@ -4,12 +4,12 @@ module SamlIdp
     let(:reference_id) { "abc" }
     let(:digest) { "em8csGAWynywpe8S4nN64o56/4DosXi2XWMY6RJ6YfA=" }
     let(:algorithm) { :sha256 }
-    let(:audience_uri) { '' }
+    let(:new_cert) { false }
     subject { described_class.new(
       reference_id,
       digest,
       algorithm,
-      audience_uri
+      new_cert
     ) }
 
     before do
@@ -27,9 +27,7 @@ module SamlIdp
     context '#signed' do
       context 'when provider has a new certificate' do
         before do
-          allow_any_instance_of(ServiceProvider).to(
-            receive(:new_cert).and_return true
-          )
+          subject.new_cert = true
         end
 
         it 'return a different signed encoded' do

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -13,7 +13,8 @@ module SamlRequestMacros
       'http://example.com',
       requested_saml_logout_url,
       'some_name_id',
-      OpenSSL::Digest::SHA256
+      OpenSSL::Digest::SHA256,
+      false
     )
     Base64.strict_encode64(request_builder.signed)
   end


### PR DESCRIPTION
This adds certificate rotation support. It enables use of a secondary certificate by setting the new cert in the SamlIdp config object and by passing `{ new_cert: true }` in the options parameter of the `encode_response` method.