### PR TITLE
ECT-1384 Canonicalize Fix

### DIFF
--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end

--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -172,8 +172,6 @@ module SamlIdp
         if element = REXML::XPath.first(self, "//ec:InclusiveNamespaces", { "ec" => C14N })
           prefix_list = element.attributes.get_attribute("PrefixList").value
           prefix_list.split(" ")
-        else
-          []
         end
       end
     end


### PR DESCRIPTION
This PR fixes and issue caused by a change to the Nokogiri gem which caused an error while trying to verify signed SAML requests leading to this exception being raised during signature verification:

`RuntimeError:  This canonicalizer does not support this operation`

See [here](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#error-handling) for details of the Nokogiri update.